### PR TITLE
Auto Open Binary Custom Editor | Introducing Preview Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,18 @@
         "scopeName": "source.uc.asm",
         "path": "./syntaxes/language-uc-assembly.tmLanguage"
       }
+    ],
+    "customEditors": [
+      {
+        "viewType": "codeart-binexplore.binaryEditor",
+        "displayName": "Code Art - Binary Explore",
+        "selector": [
+          {
+            "filenamePattern": "*"
+          }
+        ],
+        "priority": "option"
+      }
     ]
   },
   "activationEvents": [

--- a/package.json
+++ b/package.json
@@ -74,9 +74,62 @@
         "selector": [
           {
             "filenamePattern": "*"
+          },
+          {
+            "filenamePattern": "*.o"
+          },
+          {
+            "filenamePattern": "*.obj"
+          },
+          {
+            "filenamePattern": "*.exe"
           }
         ],
         "priority": "option"
+      }
+    ],
+    "commands": [
+      {
+        "command": "codeart-binexplore.previewBinary",
+        "title": "Preview CodeArt",
+        "category": "Binary Operations",
+        "icon": "./assets/images/logo.svg"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "codeart-binexplore.previewBinary",
+          "when": "resourceScheme == file && !explorerResourceIsFolder && (resourceExtname == '' || resourceExtname == .o || resourceExtName == .obj || resourceExtname == .exe)",
+          "group": "navigation"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "codeart-binexplore.previewBinary",
+          "when": "resourceScheme == file && (resourceExtname == '' || resourceExtname == .o || resourceExtName == .obj || resourceExtname == .exe)",
+          "group": "navigation"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "codeart-binexplore.previewBinary",
+          "when": "resourceScheme == file && (resourceExtname == '' || resourceExtname == .o || resourceExtName == .obj || resourceExtname == .exe)",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "codeart-binexplore.previewBinary",
+          "when": "resourceScheme == file && (resourceExtname == '' || resourceExtname == .o || resourceExtName == .obj || resourceExtname == .exe)"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "codeart-binexplore.previewBinary",
+        "key": "ctrl+shift+v",
+        "mac": "cmd+shift+v"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
       {
         "command": "codeart-binexplore.previewBinary",
         "key": "ctrl+shift+v",
-        "mac": "cmd+shift+v"
+        "mac": "cmd+shift+v",
+        "when": "resourceScheme == file && (resourceExtname == '' || resourceExtname == .o || resourceExtName == .obj || resourceExtname == .exe)"
       }
     ]
   },

--- a/src/explore.ts
+++ b/src/explore.ts
@@ -23,10 +23,10 @@ export async function activate(
   context: vscode.ExtensionContext,
   extensionOutputChannel: vscode.OutputChannel
 ) {
-  const disposable = await vscode.workspace.onDidChangeConfiguration(
-    handleConfigurationChange
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(handleConfigurationChange),
+    vscode.window.onDidChangeActiveTextEditor(handleStatusBarVisibility)
   );
-  context.subscriptions.push(disposable);
 
   outputChannel = extensionOutputChannel;
 
@@ -34,8 +34,6 @@ export async function activate(
     vscode.StatusBarAlignment.Right,
     100
   );
-
-  await vscode.window.onDidChangeActiveTextEditor(handleStatusBarVisibility);
 }
 
 /**

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -12,7 +12,6 @@ let outputChannel: vscode.OutputChannel;
 class CodeArtContentProvider implements vscode.TextDocumentContentProvider {
   private onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
   private content: string | undefined;
-  private filePath: string | undefined;
 
   /**
    * Provides the content for the given URI.
@@ -61,7 +60,6 @@ class CodeArtContentProvider implements vscode.TextDocumentContentProvider {
    * @param filePath The path to the binary file.
    */
   public async exploreFile(filePath: string): Promise<boolean> {
-    this.filePath = filePath;
     this.content = await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,


### PR DESCRIPTION
- Adding custom binary editor
    - The user now can select the configuration 'workbench.editor.defaultBinaryEditor' as 'codeart-binexplore.binaryEditor' and the CodeArt will be automatically displayed, bypassing the warning of editing a binary file


- Adding preview functionality
    - If the user chooses to keep the configuration 'workbench.editor.defaultBinaryEditor' as default, and opens the binaries with the default binary editor we can provide a preview option, besides the currently implemented auto-preview  in other editor
    - Within the explorer the user can right click a binary/object files, and select 'Preview CodeArt' option
    - If the active text editor is already a binary file in the native vscode text editor
        - Right click the file from the explorer and select 'Preview CodeArt'
        - From command palette, select 'Preview CodeArt' command for the active text file
        - From the editor title tab press on the 'CodeArt' icon to Preview CodeArt
        - Use keyboard shortcut 'ctrl+shift+v', 'cmd+shift+v' for previewing CodeArt for the active text file
